### PR TITLE
Enhancement - changed native android library to support android 16 KB memory page size 

### DIFF
--- a/alh_pdf_view/CHANGELOG.md
+++ b/alh_pdf_view/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.3
+⚽️ **Features**
+* Added support for Android 16 KB memory page size in PDF handling (Issue [#69](https://github.com/alhappler/alh_pdf_view/issues/69) from `E2-venkat`)
+* Migrated native PDF library from "com.github.mhiew:android-pdf-viewer:3.2.0-beta.2" to "com.github.marain87:AndroidPdfViewer:3.2.8".
+* Introduced jitpack package for "com.github.marain87:AndroidPdfViewer:3.2.8".
+
+
 ## 2.3.2
 🐛 **Bugfix** in iOS
 * fixed autozoom issue, thanks to `E2-venkat` for opening the issue (Issue [#62](https://github.com/alhappler/alh_pdf_view/issues/62))

--- a/alh_pdf_view/README.md
+++ b/alh_pdf_view/README.md
@@ -17,6 +17,7 @@ See more about the functionalities in the parameter section.
 
 ### Android
 - implemented in Kotlin with the dependency [AndroidPdfViewer](https://github.com/barteksc/AndroidPdfViewer) of **barteksc**
+- supports Android 16 KB memory page size
 
 ### iOS
 - implemented in Swift with the dependency [PDFKit](https://developer.apple.com/documentation/pdfkit)

--- a/alh_pdf_view/example/.gitignore
+++ b/alh_pdf_view/example/.gitignore
@@ -43,3 +43,7 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+/android/app/.cxx
+
+# CMake
+**/.cxx

--- a/alh_pdf_view/example/android/build.gradle
+++ b/alh_pdf_view/example/android/build.gradle
@@ -2,6 +2,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/alh_pdf_view/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/alh_pdf_view/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/alh_pdf_view/example/android/settings.gradle
+++ b/alh_pdf_view/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id 'com.android.application' version '8.1.0' apply false
+    id 'com.android.application' version '8.9.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
 }
 

--- a/alh_pdf_view/example/pubspec.lock
+++ b/alh_pdf_view/example/pubspec.lock
@@ -33,42 +33,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -81,10 +81,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -97,10 +97,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -138,18 +138,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -170,10 +170,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -186,18 +186,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -266,10 +266,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "5.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -279,26 +279,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: "direct dev"
     description:
@@ -311,10 +311,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   sync_http:
     dependency: transitive
     description:
@@ -327,18 +327,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
@@ -351,10 +351,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.3.1"
   webdriver:
     dependency: transitive
     description:
@@ -372,5 +372,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.24.0"

--- a/alh_pdf_view/pubspec.yaml
+++ b/alh_pdf_view/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alh_pdf_view
 description: Has the functionality to show PDF with bytes of a file path as widget with some extra functionalities.
-version: 2.3.2
+version: 2.3.3
 repository: https://github.com/alhappler/alh_pdf_view
 
 environment:
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  alh_pdf_view_android: ^2.3.1
+  alh_pdf_view_android: ^2.3.3
   alh_pdf_view_ios: ^2.3.2
   alh_pdf_view_platform_interface: ^2.3.1
 

--- a/alh_pdf_view_android/CHANGELOG.md
+++ b/alh_pdf_view_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.3
+* Added support for Android 16 KB memory page size in PDF handling (Issue [#69](https://github.com/alhappler/alh_pdf_view/issues/69) from `E2-venkat`)
+* Migrated native PDF library from "com.github.mhiew:android-pdf-viewer:3.2.0-beta.2" to "com.github.marain87:AndroidPdfViewer:3.2.8".
+* Introduced jitpack package for "com.github.marain87:AndroidPdfViewer:3.2.8".
+
 ## 2.3.1
 * updated `updateBytes` to `refreshPdf` to react also to path updates
 

--- a/alh_pdf_view_android/android/build.gradle
+++ b/alh_pdf_view_android/android/build.gradle
@@ -18,6 +18,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 
@@ -52,7 +53,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.github.mhiew:android-pdf-viewer:3.2.0-beta.2'
+        implementation 'com.github.marain87:AndroidPdfViewer:3.2.8'
     }
 
     testOptions {

--- a/alh_pdf_view_android/pubspec.yaml
+++ b/alh_pdf_view_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: alh_pdf_view_android
 description: Android implementation of the alh_pdf_view plugin. You should use the package alh_pdf_view to get working with this package.
 repository: https://github.com/alhappler/alh_pdf_view/alh_pdf_view_android
-version: 2.3.1
+version: 2.3.3
 
 environment:
   sdk: '>=3.3.1 <4.0.0'


### PR DESCRIPTION
1. Migrated native PDF library from "com.github.mhiew:android-pdf-viewer:3.2.0-beta.2" to  "com.github.marain87:AndroidPdfViewer:3.2.8" ,
2. Introduced jitpack package for "com.github.marain87:AndroidPdfViewer:3.2.8" ,
3. Upgraded example file Gradle wrapper to version 8.11.1,
4. Upgraded example file Android Gradle Plugin (AGP) to version 8.9.1 ,
5. Upgraded CHANGELOG , README , pubspec.yaml to match the above


Related to [https://github.com/alhappler/alh_pdf_view/issues/69](url)